### PR TITLE
Add Fomantic Header

### DIFF
--- a/repository/CodeParadise-WebApplication-Fomantic/CpFomanticExamplesClientBehavior.class.st
+++ b/repository/CodeParadise-WebApplication-Fomantic/CpFomanticExamplesClientBehavior.class.st
@@ -125,6 +125,43 @@ CpFomanticExamplesClientBehavior >> exampleCheckbox [
 ]
 
 { #category : #examples }
+CpFomanticExamplesClientBehavior >> exampleHeader [
+
+	<example: 'Header' order: 500>
+
+	| outputElement |
+
+	outputElement := self outputElement.
+	outputElement textContent: ''.
+
+	outputElement appendChild: (FuiHeader newLabeled: 'Header').
+	
+	outputElement appendChild: ((FuiHeader newLabeled: 'Disabled Header')
+		disable;
+		yourself).
+
+	outputElement appendChild: ((FuiHeader newLabeled: 'Huge Header')
+		beSizeHuge;
+		yourself).
+
+	outputElement appendChild: ((FuiHeader newLabeled: 'Large Header')
+		beSizeLarge;
+		yourself).
+
+	outputElement appendChild: ((FuiHeader newLabeled: 'Medium Header')
+		beSizeMedium;
+		yourself).
+
+	outputElement appendChild: ((FuiHeader newLabeled: 'Small Header')
+		beSizeSmall;
+		yourself).
+
+	outputElement appendChild: ((FuiHeader newLabeled: 'Tiny Header')
+		beSizeTiny;
+		yourself)
+]
+
+{ #category : #examples }
 CpFomanticExamplesClientBehavior >> exampleInput [
 
 	<example: 'Input' order: 200>

--- a/repository/CodeParadise-WebApplication-Fomantic/FuiHeader.class.st
+++ b/repository/CodeParadise-WebApplication-Fomantic/FuiHeader.class.st
@@ -1,0 +1,75 @@
+Class {
+	#name : #FuiHeader,
+	#superclass : #FuiElement,
+	#category : #'CodeParadise-WebApplication-Fomantic-Elements'
+}
+
+{ #category : #accessing }
+FuiHeader class >> allSizeVariations [
+
+	^ #(#tiny #small #medium #large #huge)
+]
+
+{ #category : #accessing }
+FuiHeader class >> allStates [
+
+	"Answer a collection (of Symbols) representing all states of the receiver"
+
+	^ #(#disabled)
+]
+
+{ #category : #accessing }
+FuiHeader class >> baseElementTagName [
+
+	^ #div
+]
+
+{ #category : #accessing }
+FuiHeader class >> newLabeled: aString [
+
+	^ self new
+		textContent: aString ;
+		yourself
+]
+
+{ #category : #protocol }
+FuiHeader >> beSizeHuge [
+
+	self setVariation: #huge ofVariations: self class allSizeVariations
+]
+
+{ #category : #protocol }
+FuiHeader >> beSizeLarge [
+
+	self setVariation: #large ofVariations: self class allSizeVariations
+]
+
+{ #category : #protocol }
+FuiHeader >> beSizeMedium [
+
+	self setVariation: #medium ofVariations: self class allSizeVariations
+]
+
+{ #category : #protocol }
+FuiHeader >> beSizeSmall [
+
+	self setVariation: #small ofVariations: self class allSizeVariations
+]
+
+{ #category : #protocol }
+FuiHeader >> beSizeTiny [
+
+	self setVariation: #tiny ofVariations: self class allSizeVariations
+]
+
+{ #category : #protocol }
+FuiHeader >> disable [
+
+	self addState: #disabled
+]
+
+{ #category : #protocol }
+FuiHeader >> enable [
+
+	self removeState: #disabled
+]


### PR DESCRIPTION
Hi,

I added a minimal FuiHeader class as a start to implement the Fomantic Header element, see:
https://fomantic-ui.com/elements/header.html

I am not sure how to distinguish between Page Headers which use h1 to h5 tags and Content Headers which use div tags. I must decide which tag to return in FuiHeader class>>#baseElementTagName.

While the Fomantic code examples use "ui medium header" as CSS class, CodeParadise generates "ui header medium". While it seems to work, I wonder if I have done something wrong. I copied the size variations handling from FuiInput.

Cheers,
Bernhard