### PR TITLE
Avoid modifying a literal string for not raising ModificationForbidden error on Pharo 10

### DIFF
--- a/repository/CodeParadise-WebApplication-Presentation/CpIntroductionPresentationWebApplication.class.st
+++ b/repository/CodeParadise-WebApplication-Presentation/CpIntroductionPresentationWebApplication.class.st
@@ -186,7 +186,7 @@ CpIntroductionPresentationWebApplication >> createModelClassSlide [
 					yourself) ;
 				addBullet: (CpDemoApplicationCodeContent new
 					code: ('self presentation currentSlide content
-	addBullet: (CpTextContent text: ''Added dynamically'')' replaceAll: Character cr with: Character lf) ;
+	addBullet: (CpTextContent text: ''Added dynamically'')' copyReplaceAll: String cr with: String lf) ;
 					yourself) ;
 				yourself) ;
 			yourself) ;


### PR DESCRIPTION
In Pharo 10, I found that we cannot open 'presentaion' example, because of ModificationForbidden error.
![2023-02-09 15_00_43-C__Users_ume_Documents_Pharo_images_Pharo 10 0 - CodeParadise_Pharo 10 0 - CodeP](https://user-images.githubusercontent.com/705350/217734787-b6a3cc2d-33cf-4afb-9fd3-30145172bd39.png)

Literal strings are not modifyable in Pharo 10, so I slightly changed string replacement code in the presentation example.
After the change, 'presentation' page is shown again!
![2023-02-09 15_22_34-CodeParadise](https://user-images.githubusercontent.com/705350/217735214-c5646aee-d98e-40e7-8c91-acf5b4e3ee5d.png)

