### PR TITLE
CpTransaction class>>performTransitions now properly removes finished transitions

### DIFF
--- a/repository/CodeParadise-WebApplication/CpTransition.class.st
+++ b/repository/CodeParadise-WebApplication/CpTransition.class.st
@@ -174,7 +174,7 @@ CpTransition class >> performTransitions [
 
 	"Handle 'ticking' all transitions of the receiver"
 
-	| currentTick finishedTransitions index |
+	| currentTick finishedTransitions |
 
 	Transitions ifEmpty: [ ^ self ].
 
@@ -191,14 +191,7 @@ CpTransition class >> performTransitions [
 					ifFalse: [ false "keep transition because it runs in the future" ] ]
 			ifNil: [ true "remove transition because it has no start time" ] ].
 
-	"Remove all transitions which have finished.
-	Use a reverse lookup for performance (typically iterating over few items)."
-	index := Transitions size.
-	finishedTransitions reverseDo: [ :each |
-		(Transitions lastIndexOf: each startingAt: index ifAbsent: [ nil ])
-			ifNotNil: [ :foundIndex |
-				Transitions removeAt: foundIndex.
-				index := foundIndex ] ]
+	self unregisterFinishedTransitions: finishedTransitions startingFrom: Transitions size
 ]
 
 { #category : #'class initialization' }
@@ -234,6 +227,26 @@ CpTransition class >> tickCount [
 	<primitive: 'primitiveTransitionTickCount' module: 'CpDOMPlugin'>
 	self primitiveFailed
 
+]
+
+{ #category : #'processing - private' }
+CpTransition class >> unregisterFinishedTransitions: finishedTransitions startingFrom: startIndex [
+	"Remove all transitions which have finished.
+	Use a reverse lookup for performance (typically iterating over few items)."
+
+	| index currentTransitions |
+	index := startIndex.
+
+	"For avoiding 'Transitions' class variable captured as nil in reverseDo: block. (Bug in SqueakJS?)"
+	currentTransitions := Transitions.
+
+	finishedTransitions reverseDo: [ :each |
+		(currentTransitions
+			 lastIndexOf: each
+			 startingAt: index
+			 ifAbsent: [ nil ]) ifNotNil: [ :foundIndex |
+			currentTransitions removeAt: foundIndex.
+			index := foundIndex - 1 ] ]
 ]
 
 { #category : #'accessing - private' }


### PR DESCRIPTION
I found that after performing CpTransition, MessageNotUnderstood errors are continuously displayed in JavaScript console.
![2023-03-14 01_24_31-DevTools - localhost_8080_static_app html_ChartJS-Examples](https://user-images.githubusercontent.com/705350/225349311-4c0bab1e-7512-4b4e-a8fe-24481750e8ba.png)

After some tracing, I found that `Transitions` class variable is accidentally `nil` in the `reverseDo:` block.
At the latter part of CpTransaction class>>performTransitions:
```
finishedTransitions reverseDo: [ :each |
		(Transitions "<-strangely nil!" lastIndexOf: each startingAt: index ifAbsent: [ nil ])
``` 

It seems to be an optimization bug on the SqueakJS side. As a workaround, I split this part into other method.
In the `unregisterFinishedTransitions:startingFrom:`, I use a `currentTransitions` temporary variable to refer `Transitions` in `reverseDo:` block and put some comment for this workaround.

After the change, the errors are gone and finished transitions are properly unregistered.
Please review the PR!
