### PR TITLE
Fix CpEnvironmentMethodInstallationChecker.class.st

### DIFF
--- a/repository/CodeParadise-RemoteEnvironment/CpEnvironmentMethodInstallationChecker.class.st
+++ b/repository/CodeParadise-RemoteEnvironment/CpEnvironmentMethodInstallationChecker.class.st
@@ -48,7 +48,7 @@ CpEnvironmentMethodInstallationChecker >> excludeMethod: aCompiledMethod [
 	refersToEnvironment := false.
 	isPresent := false.
 	aCompiledMethod pragmas do: [ :each |
-		each keyword = #environment:
+		each selector = #environment:
 			ifTrue: [
 				refersToEnvironment := true.
 				(each argumentAt: 1) = environmentName


### PR DESCRIPTION
keyword -> selector

keyword
	"Compatibility, Pragma until Pharo9 did not implement #selector, but #keyword. Do not use it."
	<backwardCompatible>
	
	^ self selector